### PR TITLE
Serve JSON files from Amazon S3, take 2

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -1,0 +1,15 @@
+[[source]]
+name = "pypi"
+url = "https://pypi.org/simple"
+verify_ssl = true
+
+[dev-packages]
+
+[packages]
+matplotlib = "*"
+pandas = "*"
+ansible = "*"
+boto3 = "*"
+
+[requires]
+python_version = "3.7"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,0 +1,322 @@
+{
+    "_meta": {
+        "hash": {
+            "sha256": "375aeb651309981facfff4b711477b28b09ab410ecd92de29304b28cfd2b588d"
+        },
+        "pipfile-spec": 6,
+        "requires": {
+            "python_version": "3.7"
+        },
+        "sources": [
+            {
+                "name": "pypi",
+                "url": "https://pypi.org/simple",
+                "verify_ssl": true
+            }
+        ]
+    },
+    "default": {
+        "ansible": {
+            "hashes": [
+                "sha256:e83d84ae8bf131c0499d8a4c0e1144bf969454c43086e61cca3c224227df29d1"
+            ],
+            "index": "pypi",
+            "version": "==2.9.9"
+        },
+        "boto3": {
+            "hashes": [
+                "sha256:45e851db4b4ea6cedc9e138f6aa93fedaa5a8e0ae6d8a3f893b3e27c6aff60c8",
+                "sha256:86de0882ba324ba4ced362b5c94491b8d126d378f2ee24d32486cb64b160a89f"
+            ],
+            "index": "pypi",
+            "version": "==1.13.21"
+        },
+        "botocore": {
+            "hashes": [
+                "sha256:3837f15e9ec9fd395beb0fb840a5976655c8ebb83121a4612e26f21aad8da908",
+                "sha256:7bd43e2fdf579875e3d3073e25699f5e524cc36a1748c4aee7c9c626e3760b2b"
+            ],
+            "version": "==1.16.21"
+        },
+        "cffi": {
+            "hashes": [
+                "sha256:001bf3242a1bb04d985d63e138230802c6c8d4db3668fb545fb5005ddf5bb5ff",
+                "sha256:00789914be39dffba161cfc5be31b55775de5ba2235fe49aa28c148236c4e06b",
+                "sha256:028a579fc9aed3af38f4892bdcc7390508adabc30c6af4a6e4f611b0c680e6ac",
+                "sha256:14491a910663bf9f13ddf2bc8f60562d6bc5315c1f09c704937ef17293fb85b0",
+                "sha256:1cae98a7054b5c9391eb3249b86e0e99ab1e02bb0cc0575da191aedadbdf4384",
+                "sha256:2089ed025da3919d2e75a4d963d008330c96751127dd6f73c8dc0c65041b4c26",
+                "sha256:2d384f4a127a15ba701207f7639d94106693b6cd64173d6c8988e2c25f3ac2b6",
+                "sha256:337d448e5a725bba2d8293c48d9353fc68d0e9e4088d62a9571def317797522b",
+                "sha256:399aed636c7d3749bbed55bc907c3288cb43c65c4389964ad5ff849b6370603e",
+                "sha256:3b911c2dbd4f423b4c4fcca138cadde747abdb20d196c4a48708b8a2d32b16dd",
+                "sha256:3d311bcc4a41408cf5854f06ef2c5cab88f9fded37a3b95936c9879c1640d4c2",
+                "sha256:62ae9af2d069ea2698bf536dcfe1e4eed9090211dbaafeeedf5cb6c41b352f66",
+                "sha256:66e41db66b47d0d8672d8ed2708ba91b2f2524ece3dee48b5dfb36be8c2f21dc",
+                "sha256:675686925a9fb403edba0114db74e741d8181683dcf216be697d208857e04ca8",
+                "sha256:7e63cbcf2429a8dbfe48dcc2322d5f2220b77b2e17b7ba023d6166d84655da55",
+                "sha256:8a6c688fefb4e1cd56feb6c511984a6c4f7ec7d2a1ff31a10254f3c817054ae4",
+                "sha256:8c0ffc886aea5df6a1762d0019e9cb05f825d0eec1f520c51be9d198701daee5",
+                "sha256:95cd16d3dee553f882540c1ffe331d085c9e629499ceadfbda4d4fde635f4b7d",
+                "sha256:99f748a7e71ff382613b4e1acc0ac83bf7ad167fb3802e35e90d9763daba4d78",
+                "sha256:b8c78301cefcf5fd914aad35d3c04c2b21ce8629b5e4f4e45ae6812e461910fa",
+                "sha256:c420917b188a5582a56d8b93bdd8e0f6eca08c84ff623a4c16e809152cd35793",
+                "sha256:c43866529f2f06fe0edc6246eb4faa34f03fe88b64a0a9a942561c8e22f4b71f",
+                "sha256:cab50b8c2250b46fe738c77dbd25ce017d5e6fb35d3407606e7a4180656a5a6a",
+                "sha256:cef128cb4d5e0b3493f058f10ce32365972c554572ff821e175dbc6f8ff6924f",
+                "sha256:cf16e3cf6c0a5fdd9bc10c21687e19d29ad1fe863372b5543deaec1039581a30",
+                "sha256:e56c744aa6ff427a607763346e4170629caf7e48ead6921745986db3692f987f",
+                "sha256:e577934fc5f8779c554639376beeaa5657d54349096ef24abe8c74c5d9c117c3",
+                "sha256:f2b0fa0c01d8a0c7483afd9f31d7ecf2d71760ca24499c8697aeb5ca37dc090c"
+            ],
+            "version": "==1.14.0"
+        },
+        "cryptography": {
+            "hashes": [
+                "sha256:091d31c42f444c6f519485ed528d8b451d1a0c7bf30e8ca583a0cac44b8a0df6",
+                "sha256:18452582a3c85b96014b45686af264563e3e5d99d226589f057ace56196ec78b",
+                "sha256:1dfa985f62b137909496e7fc182dac687206d8d089dd03eaeb28ae16eec8e7d5",
+                "sha256:1e4014639d3d73fbc5ceff206049c5a9a849cefd106a49fa7aaaa25cc0ce35cf",
+                "sha256:22e91636a51170df0ae4dcbd250d318fd28c9f491c4e50b625a49964b24fe46e",
+                "sha256:3b3eba865ea2754738616f87292b7f29448aec342a7c720956f8083d252bf28b",
+                "sha256:651448cd2e3a6bc2bb76c3663785133c40d5e1a8c1a9c5429e4354201c6024ae",
+                "sha256:726086c17f94747cedbee6efa77e99ae170caebeb1116353c6cf0ab67ea6829b",
+                "sha256:844a76bc04472e5135b909da6aed84360f522ff5dfa47f93e3dd2a0b84a89fa0",
+                "sha256:88c881dd5a147e08d1bdcf2315c04972381d026cdb803325c03fe2b4a8ed858b",
+                "sha256:96c080ae7118c10fcbe6229ab43eb8b090fccd31a09ef55f83f690d1ef619a1d",
+                "sha256:a0c30272fb4ddda5f5ffc1089d7405b7a71b0b0f51993cb4e5dbb4590b2fc229",
+                "sha256:bb1f0281887d89617b4c68e8db9a2c42b9efebf2702a3c5bf70599421a8623e3",
+                "sha256:c447cf087cf2dbddc1add6987bbe2f767ed5317adb2d08af940db517dd704365",
+                "sha256:c4fd17d92e9d55b84707f4fd09992081ba872d1a0c610c109c18e062e06a2e55",
+                "sha256:d0d5aeaedd29be304848f1c5059074a740fa9f6f26b84c5b63e8b29e73dfc270",
+                "sha256:daf54a4b07d67ad437ff239c8a4080cfd1cc7213df57d33c97de7b4738048d5e",
+                "sha256:e993468c859d084d5579e2ebee101de8f5a27ce8e2159959b6673b418fd8c785",
+                "sha256:f118a95c7480f5be0df8afeb9a11bd199aa20afab7a96bcf20409b411a3a85f0"
+            ],
+            "version": "==2.9.2"
+        },
+        "cycler": {
+            "hashes": [
+                "sha256:1d8a5ae1ff6c5cf9b93e8811e581232ad8920aeec647c37316ceac982b08cb2d",
+                "sha256:cd7b2d1018258d7247a71425e9f26463dfb444d411c39569972f4ce586b0c9d8"
+            ],
+            "version": "==0.10.0"
+        },
+        "docutils": {
+            "hashes": [
+                "sha256:6c4f696463b79f1fb8ba0c594b63840ebd41f059e92b31957c46b74a4599b6d0",
+                "sha256:9e4d7ecfc600058e07ba661411a2b7de2fd0fafa17d1a7f7361cd47b1175c827",
+                "sha256:a2aeea129088da402665e92e0b25b04b073c04b2dce4ab65caaa38b7ce2e1a99"
+            ],
+            "version": "==0.15.2"
+        },
+        "jinja2": {
+            "hashes": [
+                "sha256:89aab215427ef59c34ad58735269eb58b1a5808103067f7bb9d5836c651b3bb0",
+                "sha256:f0a4641d3cf955324a89c04f3d94663aa4d638abe8f733ecd3582848e1c37035"
+            ],
+            "version": "==2.11.2"
+        },
+        "jmespath": {
+            "hashes": [
+                "sha256:b85d0567b8666149a93172712e68920734333c0ce7e89b78b3e987f71e5ed4f9",
+                "sha256:cdf6525904cc597730141d61b36f2e4b8ecc257c420fa2f4549bac2c2d0cb72f"
+            ],
+            "version": "==0.10.0"
+        },
+        "kiwisolver": {
+            "hashes": [
+                "sha256:03662cbd3e6729f341a97dd2690b271e51a67a68322affab12a5b011344b973c",
+                "sha256:18d749f3e56c0480dccd1714230da0f328e6e4accf188dd4e6884bdd06bf02dd",
+                "sha256:247800260cd38160c362d211dcaf4ed0f7816afb5efe56544748b21d6ad6d17f",
+                "sha256:443c2320520eda0a5b930b2725b26f6175ca4453c61f739fef7a5847bd262f74",
+                "sha256:4eadb361baf3069f278b055e3bb53fa189cea2fd02cb2c353b7a99ebb4477ef1",
+                "sha256:556da0a5f60f6486ec4969abbc1dd83cf9b5c2deadc8288508e55c0f5f87d29c",
+                "sha256:603162139684ee56bcd57acc74035fceed7dd8d732f38c0959c8bd157f913fec",
+                "sha256:60a78858580761fe611d22127868f3dc9f98871e6fdf0a15cc4203ed9ba6179b",
+                "sha256:7cc095a4661bdd8a5742aaf7c10ea9fac142d76ff1770a0f84394038126d8fc7",
+                "sha256:c31bc3c8e903d60a1ea31a754c72559398d91b5929fcb329b1c3a3d3f6e72113",
+                "sha256:c955791d80e464da3b471ab41eb65cf5a40c15ce9b001fdc5bbc241170de58ec",
+                "sha256:d069ef4b20b1e6b19f790d00097a5d5d2c50871b66d10075dab78938dc2ee2cf",
+                "sha256:d52b989dc23cdaa92582ceb4af8d5bcc94d74b2c3e64cd6785558ec6a879793e",
+                "sha256:e586b28354d7b6584d8973656a7954b1c69c93f708c0c07b77884f91640b7657",
+                "sha256:efcf3397ae1e3c3a4a0a0636542bcad5adad3b1dd3e8e629d0b6e201347176c8",
+                "sha256:fccefc0d36a38c57b7bd233a9b485e2f1eb71903ca7ad7adacad6c28a56d62d2"
+            ],
+            "version": "==1.2.0"
+        },
+        "markupsafe": {
+            "hashes": [
+                "sha256:00bc623926325b26bb9605ae9eae8a215691f33cae5df11ca5424f06f2d1f473",
+                "sha256:09027a7803a62ca78792ad89403b1b7a73a01c8cb65909cd876f7fcebd79b161",
+                "sha256:09c4b7f37d6c648cb13f9230d847adf22f8171b1ccc4d5682398e77f40309235",
+                "sha256:1027c282dad077d0bae18be6794e6b6b8c91d58ed8a8d89a89d59693b9131db5",
+                "sha256:13d3144e1e340870b25e7b10b98d779608c02016d5184cfb9927a9f10c689f42",
+                "sha256:24982cc2533820871eba85ba648cd53d8623687ff11cbb805be4ff7b4c971aff",
+                "sha256:29872e92839765e546828bb7754a68c418d927cd064fd4708fab9fe9c8bb116b",
+                "sha256:43a55c2930bbc139570ac2452adf3d70cdbb3cfe5912c71cdce1c2c6bbd9c5d1",
+                "sha256:46c99d2de99945ec5cb54f23c8cd5689f6d7177305ebff350a58ce5f8de1669e",
+                "sha256:500d4957e52ddc3351cabf489e79c91c17f6e0899158447047588650b5e69183",
+                "sha256:535f6fc4d397c1563d08b88e485c3496cf5784e927af890fb3c3aac7f933ec66",
+                "sha256:596510de112c685489095da617b5bcbbac7dd6384aeebeda4df6025d0256a81b",
+                "sha256:62fe6c95e3ec8a7fad637b7f3d372c15ec1caa01ab47926cfdf7a75b40e0eac1",
+                "sha256:6788b695d50a51edb699cb55e35487e430fa21f1ed838122d722e0ff0ac5ba15",
+                "sha256:6dd73240d2af64df90aa7c4e7481e23825ea70af4b4922f8ede5b9e35f78a3b1",
+                "sha256:717ba8fe3ae9cc0006d7c451f0bb265ee07739daf76355d06366154ee68d221e",
+                "sha256:79855e1c5b8da654cf486b830bd42c06e8780cea587384cf6545b7d9ac013a0b",
+                "sha256:7c1699dfe0cf8ff607dbdcc1e9b9af1755371f92a68f706051cc8c37d447c905",
+                "sha256:88e5fcfb52ee7b911e8bb6d6aa2fd21fbecc674eadd44118a9cc3863f938e735",
+                "sha256:8defac2f2ccd6805ebf65f5eeb132adcf2ab57aa11fdf4c0dd5169a004710e7d",
+                "sha256:98c7086708b163d425c67c7a91bad6e466bb99d797aa64f965e9d25c12111a5e",
+                "sha256:9add70b36c5666a2ed02b43b335fe19002ee5235efd4b8a89bfcf9005bebac0d",
+                "sha256:9bf40443012702a1d2070043cb6291650a0841ece432556f784f004937f0f32c",
+                "sha256:ade5e387d2ad0d7ebf59146cc00c8044acbd863725f887353a10df825fc8ae21",
+                "sha256:b00c1de48212e4cc9603895652c5c410df699856a2853135b3967591e4beebc2",
+                "sha256:b1282f8c00509d99fef04d8ba936b156d419be841854fe901d8ae224c59f0be5",
+                "sha256:b2051432115498d3562c084a49bba65d97cf251f5a331c64a12ee7e04dacc51b",
+                "sha256:ba59edeaa2fc6114428f1637ffff42da1e311e29382d81b339c1817d37ec93c6",
+                "sha256:c8716a48d94b06bb3b2524c2b77e055fb313aeb4ea620c8dd03a105574ba704f",
+                "sha256:cd5df75523866410809ca100dc9681e301e3c27567cf498077e8551b6d20e42f",
+                "sha256:cdb132fc825c38e1aeec2c8aa9338310d29d337bebbd7baa06889d09a60a1fa2",
+                "sha256:e249096428b3ae81b08327a63a485ad0878de3fb939049038579ac0ef61e17e7",
+                "sha256:e8313f01ba26fbbe36c7be1966a7b7424942f670f38e666995b88d012765b9be"
+            ],
+            "version": "==1.1.1"
+        },
+        "matplotlib": {
+            "hashes": [
+                "sha256:2466d4dddeb0f5666fd1e6736cc5287a4f9f7ae6c1a9e0779deff798b28e1d35",
+                "sha256:282b3fc8023c4365bad924d1bb442ddc565c2d1635f210b700722776da466ca3",
+                "sha256:4bb50ee4755271a2017b070984bcb788d483a8ce3132fab68393d1555b62d4ba",
+                "sha256:56d3147714da5c7ac4bc452d041e70e0e0b07c763f604110bd4e2527f320b86d",
+                "sha256:7a9baefad265907c6f0b037c8c35a10cf437f7708c27415a5513cf09ac6d6ddd",
+                "sha256:aae7d107dc37b4bb72dcc45f70394e6df2e5e92ac4079761aacd0e2ad1d3b1f7",
+                "sha256:af14e77829c5b5d5be11858d042d6f2459878f8e296228c7ea13ec1fd308eb68",
+                "sha256:c1cf735970b7cd424502719b44288b21089863aaaab099f55e0283a721aaf781",
+                "sha256:ce378047902b7a05546b6485b14df77b2ff207a0054e60c10b5680132090c8ee",
+                "sha256:d35891a86a4388b6965c2d527b9a9f9e657d9e110b0575ca8a24ba0d4e34b8fc",
+                "sha256:e06304686209331f99640642dee08781a9d55c6e32abb45ed54f021f46ccae47",
+                "sha256:e20ba7fb37d4647ac38f3c6d8672dd8b62451ee16173a0711b37ba0ce42bf37d",
+                "sha256:f4412241e32d0f8d3713b68d3ca6430190a5e8a7c070f1c07d7833d8c5264398",
+                "sha256:ffe2f9cdcea1086fc414e82f42271ecf1976700b8edd16ca9d376189c6d93aee"
+            ],
+            "index": "pypi",
+            "version": "==3.2.1"
+        },
+        "numpy": {
+            "hashes": [
+                "sha256:00d7b54c025601e28f468953d065b9b121ddca7fff30bed7be082d3656dd798d",
+                "sha256:02ec9582808c4e48be4e93cd629c855e644882faf704bc2bd6bbf58c08a2a897",
+                "sha256:0e6f72f7bb08f2f350ed4408bb7acdc0daba637e73bce9f5ea2b207039f3af88",
+                "sha256:1be2e96314a66f5f1ce7764274327fd4fb9da58584eaff00b5a5221edefee7d6",
+                "sha256:2466fbcf23711ebc5daa61d28ced319a6159b260a18839993d871096d66b93f7",
+                "sha256:2b573fcf6f9863ce746e4ad00ac18a948978bb3781cffa4305134d31801f3e26",
+                "sha256:3f0dae97e1126f529ebb66f3c63514a0f72a177b90d56e4bce8a0b5def34627a",
+                "sha256:50fb72bcbc2cf11e066579cb53c4ca8ac0227abb512b6cbc1faa02d1595a2a5d",
+                "sha256:57aea170fb23b1fd54fa537359d90d383d9bf5937ee54ae8045a723caa5e0961",
+                "sha256:709c2999b6bd36cdaf85cf888d8512da7433529f14a3689d6e37ab5242e7add5",
+                "sha256:7d59f21e43bbfd9a10953a7e26b35b6849d888fc5a331fa84a2d9c37bd9fe2a2",
+                "sha256:904b513ab8fbcbdb062bed1ce2f794ab20208a1b01ce9bd90776c6c7e7257032",
+                "sha256:96dd36f5cdde152fd6977d1bbc0f0561bccffecfde63cd397c8e6033eb66baba",
+                "sha256:9933b81fecbe935e6a7dc89cbd2b99fea1bf362f2790daf9422a7bb1dc3c3085",
+                "sha256:bbcc85aaf4cd84ba057decaead058f43191cc0e30d6bc5d44fe336dc3d3f4509",
+                "sha256:dccd380d8e025c867ddcb2f84b439722cf1f23f3a319381eac45fd077dee7170",
+                "sha256:e22cd0f72fc931d6abc69dc7764484ee20c6a60b0d0fee9ce0426029b1c1bdae",
+                "sha256:ed722aefb0ebffd10b32e67f48e8ac4c5c4cf5d3a785024fdf0e9eb17529cd9d",
+                "sha256:efb7ac5572c9a57159cf92c508aad9f856f1cb8e8302d7fdb99061dbe52d712c",
+                "sha256:efdba339fffb0e80fcc19524e4fdbda2e2b5772ea46720c44eaac28096d60720",
+                "sha256:f22273dd6a403ed870207b853a856ff6327d5cbce7a835dfa0645b3fc00273ec"
+            ],
+            "version": "==1.18.4"
+        },
+        "pandas": {
+            "hashes": [
+                "sha256:034185bb615dc96d08fa13aacba8862949db19d5e7804d6ee242d086f07bcc46",
+                "sha256:0c9b7f1933e3226cc16129cf2093338d63ace5c85db7c9588e3e1ac5c1937ad5",
+                "sha256:1f6fcf0404626ca0475715da045a878c7062ed39bc859afc4ccf0ba0a586a0aa",
+                "sha256:1fc963ba33c299973e92d45466e576d11f28611f3549469aec4a35658ef9f4cc",
+                "sha256:29b4cfee5df2bc885607b8f016e901e63df7ffc8f00209000471778f46cc6678",
+                "sha256:2a8b6c28607e3f3c344fe3e9b3cd76d2bf9f59bc8c0f2e582e3728b80e1786dc",
+                "sha256:2bc2ff52091a6ac481cc75d514f06227dc1b10887df1eb72d535475e7b825e31",
+                "sha256:415e4d52fcfd68c3d8f1851cef4d947399232741cc994c8f6aa5e6a9f2e4b1d8",
+                "sha256:519678882fd0587410ece91e3ff7f73ad6ded60f6fcb8aa7bcc85c1dc20ecac6",
+                "sha256:51e0abe6e9f5096d246232b461649b0aa627f46de8f6344597ca908f2240cbaa",
+                "sha256:698e26372dba93f3aeb09cd7da2bb6dd6ade248338cfe423792c07116297f8f4",
+                "sha256:83af85c8e539a7876d23b78433d90f6a0e8aa913e37320785cf3888c946ee874",
+                "sha256:982cda36d1773076a415ec62766b3c0a21cdbae84525135bdb8f460c489bb5dd",
+                "sha256:a647e44ba1b3344ebc5991c8aafeb7cca2b930010923657a273b41d86ae225c4",
+                "sha256:b35d625282baa7b51e82e52622c300a1ca9f786711b2af7cbe64f1e6831f4126",
+                "sha256:bab51855f8b318ef39c2af2c11095f45a10b74cbab4e3c8199efcc5af314c648"
+            ],
+            "index": "pypi",
+            "version": "==1.0.4"
+        },
+        "pycparser": {
+            "hashes": [
+                "sha256:2d475327684562c3a96cc71adf7dc8c4f0565175cf86b6d7a404ff4c771f15f0",
+                "sha256:7582ad22678f0fcd81102833f60ef8d0e57288b6b5fb00323d101be910e35705"
+            ],
+            "version": "==2.20"
+        },
+        "pyparsing": {
+            "hashes": [
+                "sha256:c203ec8783bf771a155b207279b9bccb8dea02d8f0c9e5f8ead507bc3246ecc1",
+                "sha256:ef9d7589ef3c200abe66653d3f1ab1033c3c419ae9b9bdb1240a85b024efc88b"
+            ],
+            "version": "==2.4.7"
+        },
+        "python-dateutil": {
+            "hashes": [
+                "sha256:73ebfe9dbf22e832286dafa60473e4cd239f8592f699aa5adaf10050e6e1823c",
+                "sha256:75bb3f31ea686f1197762692a9ee6a7550b59fc6ca3a1f4b5d7e32fb98e2da2a"
+            ],
+            "version": "==2.8.1"
+        },
+        "pytz": {
+            "hashes": [
+                "sha256:a494d53b6d39c3c6e44c3bec237336e14305e4f29bbf800b599253057fbb79ed",
+                "sha256:c35965d010ce31b23eeb663ed3cc8c906275d6be1a34393a1d73a41febf4a048"
+            ],
+            "version": "==2020.1"
+        },
+        "pyyaml": {
+            "hashes": [
+                "sha256:06a0d7ba600ce0b2d2fe2e78453a470b5a6e000a985dd4a4e54e436cc36b0e97",
+                "sha256:240097ff019d7c70a4922b6869d8a86407758333f02203e0fc6ff79c5dcede76",
+                "sha256:4f4b913ca1a7319b33cfb1369e91e50354d6f07a135f3b901aca02aa95940bd2",
+                "sha256:69f00dca373f240f842b2931fb2c7e14ddbacd1397d57157a9b005a6a9942648",
+                "sha256:73f099454b799e05e5ab51423c7bcf361c58d3206fa7b0d555426b1f4d9a3eaf",
+                "sha256:74809a57b329d6cc0fdccee6318f44b9b8649961fa73144a98735b0aaf029f1f",
+                "sha256:7739fc0fa8205b3ee8808aea45e968bc90082c10aef6ea95e855e10abf4a37b2",
+                "sha256:95f71d2af0ff4227885f7a6605c37fd53d3a106fcab511b8860ecca9fcf400ee",
+                "sha256:b8eac752c5e14d3eca0e6dd9199cd627518cb5ec06add0de9d32baeee6fe645d",
+                "sha256:cc8955cfbfc7a115fa81d85284ee61147059a753344bc51098f3ccd69b0d7e0c",
+                "sha256:d13155f591e6fcc1ec3b30685d50bf0711574e2c0dfffd7644babf8b5102ca1a"
+            ],
+            "version": "==5.3.1"
+        },
+        "s3transfer": {
+            "hashes": [
+                "sha256:2482b4259524933a022d59da830f51bd746db62f047d6eb213f2f8855dcb8a13",
+                "sha256:921a37e2aefc64145e7b73d50c71bb4f26f46e4c9f414dc648c6245ff92cf7db"
+            ],
+            "version": "==0.3.3"
+        },
+        "six": {
+            "hashes": [
+                "sha256:30639c035cdb23534cd4aa2dd52c3bf48f06e5f4a941509c8bafd8ce11080259",
+                "sha256:8b74bedcbbbaca38ff6d7491d76f2b06b3592611af620f8426e82dddb04a5ced"
+            ],
+            "version": "==1.15.0"
+        },
+        "urllib3": {
+            "hashes": [
+                "sha256:3018294ebefce6572a474f0604c2021e33b3fd8006ecd11d62107a5d2a963527",
+                "sha256:88206b0eb87e6d677d424843ac5209e3fb9d0190d0ee169599165ec25e9d9115"
+            ],
+            "markers": "python_version != '3.4'",
+            "version": "==1.25.9"
+        }
+    },
+    "develop": {}
+}

--- a/README.md
+++ b/README.md
@@ -7,31 +7,23 @@ Created by: Olha Buchel from the New England Complex Systems Institute
 
 Code to generate the interactive maps at  <https://www.endcoronavirus.org/us-counties>
 
+## Installation
+
+You can install dependencies (e.g. pandas, ansible, boto3)  for this project by using [pipenv](https://pipenv.pypa.io/en/latest/).
+
+    $ pipenv install
+    $ pipenv shell
+    
+This creates a local environment with all necessary packages installed.
+
 ## Web site setup and data flow
 
 The page <https://www.endcoronavirus.org/us-counties> is hosted by SquareSpace.
 It embeds <https://obuchel.github.io/classification/classification_map.html> in an IFrame.
 
-In the source code of that HTML page you find several data sources
-
-```js
-fetch('classification/classification_ids_counties2.json')
-
-fetch('counties.json')
- 
- if (["630","16","316","580","850"].indexOf(num)>-1) {
-    
-    var url='classification/data_counties_'+num+'.json';
-} else {
-    
-    var url='classification/data_counties_840'+num+'.json';
-}
-fetch(url)
-```
-
 ### classification/classification_ids_counties2.json
 
-Has records like 
+Contains the county-by-county classification with records like 
 ```json
 {
     "n": "Cuming, Nebraska, US",
@@ -113,13 +105,9 @@ My interpretation for the fields:
 The script `prepare_classification_counties_final.py` is used to write the JSON files for the website.
 Just like with the JavaScript on the web page, you can look for `open()` in the python file.
 
-### my_ids.json
-
-This looks unused.
-
-### Reading CSSEGISandData
+### Reading: CSSEGISandData
  
-https://raw.githubusercontent.com/CSSEGISandData/COVID-19/master/csse_covid_19_data/csse_covid_19_time_series/time_series_covid19_confirmed_US.csv')
+https://raw.githubusercontent.com/CSSEGISandData/COVID-19/master/csse_covid_19_data/csse_covid_19_time_series/time_series_covid19_confirmed_US.csv
 
 
 ### Writing: 'data_counties_'+str(ids[recs.index(name)]["UID"])+'.json'
@@ -158,6 +146,73 @@ This is a list of records like this:
     "max": int(max(y5))
 }
 ```
-presumably one entry per county.
+with one entry per county.
 This file is apparently included in the github repository
 as classification/classification_ids_counties2.json.
+
+## Development
+
+### Testing locally
+
+Run a local web server
+
+    $ python -m http.server
+
+Then open http://localhost:8000.
+This will serve JSON files directly from the local directories `output` and `data/geo`.
+
+
+# Workflow for updating the maps
+
+We want to keep the county-level JSON files out of the GitHub repository,
+therefore we serve them from an S3 bucket.
+
+
+## Setup: Get your credentials for AWS S3
+
+Make sure you have AWS credentials (Access key ID, Secret access key) for API access.
+Now we need to make the credentials accessible to the ansible playbooks (see below).
+
+### Option 1: Using the AWS command line interface
+
+Install from https://aws.amazon.com/cli/
+
+Then run 
+
+    $ aws configure
+    
+This will prompt you for your AWS Access Key ID etc.
+
+**Note:** Never commit credentials to git.
+
+### Option 2: Using direnv
+
+You can use the [direnv](https://direnv.net/) tool and create a `.envrc` file in your home directory
+
+**Note:** Never commit credentials to git.
+
+## Setup: Prepare the S3 bucket
+
+You only need to do this once:
+
+    $ ansible-playbook playbooks/setup_s3_bucket.yml
+     
+This will create an S3 bucket (if necessary) and set its permissions to public readable. It also sets up a CORS configuration that allows access to the JSON files from browsers.
+
+The name of the bucket is configured in `playbooks/settings.yml`.
+
+## Daily update
+
+To update the maps at https://www.endcoronavirus.org/us-counties:
+
+1. Check out the code locally
+2. Run `prepare_classification_counties_final.py`. The script will
+   - retrieve current data as a csv file
+   - do the analysis
+   - write one JSON file per county into `output/classification`
+3. Upload the generated files from `output/classification`  and `data/geo` to S3 with
+
+       $ ansible-playbook playbooks/upload_to_s3.yml
+       
+   Unfortunately, this may take a while, depending on your internet connection.
+   (I have seen a runtime of 27 minutes on a slow internet connection)

--- a/index.html
+++ b/index.html
@@ -1,0 +1,25 @@
+<h1>Testing</h1>
+<h2>Interactive Maps</h2>
+
+<ul>
+    <li>
+        <a href="classification_map.html">classification_map.html</a>
+        (<a href="classification_map.html?s3bucket=ecv-county-maps">use S3</a>)
+    </li>
+
+    <li>
+        <a href="classification_map2.html">classification_map2.html</a>
+        (<a href="classification_map2.html?s3bucket=ecv-county-maps">use S3</a>)
+    </li>
+
+</ul>
+
+<h1>Testing locally</h1>
+
+<pre>
+    $ python -m http.server
+
+</pre>
+Then open <a href="http://localhost:8000/">http://localhost:8000</a>.
+<p>When you test locally (on localhost:8000), data will be served from the local machine.
+If you want to test with data from S3, append the parameter <code>?s3bucket=ecv-county-maps</code> to the URL.</p>

--- a/map_impl.js
+++ b/map_impl.js
@@ -1,3 +1,14 @@
+var base_url = "";
+var found = window.location.search.match(/s3bucket=(?<bucket>.*)/);
+if (found) {
+    var bucket = found.groups.bucket;
+    // TODO: make the AWS region variable
+    base_url = "https://" + bucket + ".s3.us-east-2.amazonaws.com/";
+}
+var fetch_json = function (url) {
+    return fetch(base_url + url)
+};
+
 var popup;
  var layerM;
     var map;
@@ -11,7 +22,7 @@ var comms=["All",0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 13, 14, 15, 16, 17, 18, 1
 var data3=[];    
 
     var data0=[];
-            fetch('output/classification/classification_ids_counties2.json').then(res => res.json()) 
+            fetch_json('output/classification/classification_ids_counties2.json').then(res => res.json())
 .then(data0 => { 
              // console.log(data0);  
          var cols={"green":0,"yellow":0.1,"orange":0.4,"red":1}       
@@ -22,7 +33,7 @@ var data3=[];
                                                                      
                                                                      });
            //console.log(ids);
-        fetch('counties5.json').then(res => res.json()) 
+        fetch_json('counties5.json').then(res => res.json())
 .then(data => {  
  var data2={"type":"FeatureCollection"};
     data2["features"]=[];        
@@ -87,7 +98,7 @@ center: [-82.447303,37.753574]
             
 map.addControl(new mapboxgl.NavigationControl(), 'top-left');      
 map.addControl(new mapboxgl.FullscreenControl(), 'bottom-left');
-fetch('states5.json').then(res => res.json()) 
+fetch_json('states5.json').then(res => res.json())
 .then(data8 => {             
 
     
@@ -332,7 +343,7 @@ if (e.features[0].properties["c"]=="yellow") {
     }
     
     
-  fetch(url).then(res => res.json()) 
+  fetch_json(url).then(res => res.json())
 .then(data7 => {    
 
   

--- a/map_impl2.js
+++ b/map_impl2.js
@@ -1,3 +1,14 @@
+var base_url = "";
+var found = window.location.search.match(/s3bucket=(?<bucket>.*)/);
+if (found) {
+    var bucket = found.groups.bucket;
+    // TODO: make the AWS region variable
+    base_url = "https://" + bucket + ".s3.us-east-2.amazonaws.com/";
+}
+var fetch_json = function (url) {
+    return fetch(base_url + url)
+};
+
 var popup;
 var arr=[[-1, '#000000'],[1, '#1a9850'],[20, '#ffffb2'],[200, '#fd8d3c'],[1000, '#fc4e2a'],[20000, '#bd0026'],[30000, '#800026']];   
 var arr2=[[1, 0.1], [100, 0.2],[200, 0.7],[500, 1],[1000, 1],[2000, 1],[2500, 1],[3000, 1],[50000, 1]];  
@@ -5,13 +16,13 @@ var comms=["All",0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 13, 14, 15, 16, 17, 18, 1
 var data3=[];    
 
     var data0=[];
-            fetch('output/classification/classification_ids_counties2.json').then(res => res.json()) 
+            fetch_json('output/classification/classification_ids_counties2.json').then(res => res.json())
 .then(data0 => { 
              // console.log(data0);  
          var cols={"green":0,"yellow":0.1,"orange":0.4,"red":1}       
                 var ids=data0.map(function(d){return d.id.toString().substring(3)});
          //  console.log(ids);
-        fetch('counties5.json').then(res => res.json()) 
+        fetch_json('counties5.json').then(res => res.json())
 .then(data => {  
  
             for (var i=0; i<data["features"].length; i++) {
@@ -44,7 +55,7 @@ map.addControl(new mapboxgl.FullscreenControl(), 'bottom-left');
 map.on('load', function() {    
 
   
-fetch('states5.json').then(res => res.json()) 
+fetch_json('states5.json').then(res => res.json())
 .then(data8 => {   
      // define layer names
         var layers = [

--- a/playbooks/settings.yml
+++ b/playbooks/settings.yml
@@ -1,0 +1,2 @@
+bucket_name: ecv-county-maps
+aws_region: us-east-2

--- a/playbooks/setup_s3_bucket.yml
+++ b/playbooks/setup_s3_bucket.yml
@@ -26,5 +26,6 @@
             - "*"
           allowed_methods:
             - GET
+            - HEAD
   - debug:
       msg: "Finished setting up S3 bucket {{ bucket_name }} in region {{ aws_region }}."

--- a/playbooks/setup_s3_bucket.yml
+++ b/playbooks/setup_s3_bucket.yml
@@ -1,0 +1,30 @@
+---
+# Set up a S3 bucket with public access and CORS permissions,
+# upload county and state boundaries (all json files from data/geo).
+# This expects your AWS credentials in the AWS_ACCESS_KEY and AWS_SECRET_KEY
+# environment variables.
+
+- name: Setup S3 Bucket
+  hosts: localhost
+  gather_facts: False
+  vars_files:
+    - settings.yml
+  tasks:
+  - name: Create the bucket
+    aws_s3:
+      bucket: "{{ bucket_name }}"
+      mode: create
+      permission: public-read
+      region: "{{ aws_region }}"
+
+  - name: Set up CORS
+    aws_s3_cors:
+      name: "{{ bucket_name }}"
+      state: present
+      rules:
+        - allowed_origins:
+            - "*"
+          allowed_methods:
+            - GET
+  - debug:
+      msg: "Finished setting up S3 bucket {{ bucket_name }} in region {{ aws_region }}."

--- a/playbooks/upload_to_s3.yml
+++ b/playbooks/upload_to_s3.yml
@@ -13,12 +13,11 @@
   - name: Upload state and county boundaries
     s3_sync:
       bucket: "{{ bucket_name }}"
-      file_root: ../data/geo
-      key_prefix: data/geo
+      file_root: ..
       file_change_strategy: date_size
       permission: public-read
       cache_control: "public, max-age=604800"
-      include: "*.json"
+      include: "counties5.json,states5.json"
       region: "{{ aws_region }}"
   - name: Upload county classification data
     s3_sync:

--- a/playbooks/upload_to_s3.yml
+++ b/playbooks/upload_to_s3.yml
@@ -1,0 +1,34 @@
+---
+# Upload county classification data (all json files from output/classification)
+# to the S3 bucket.
+# This expects your AWS credentials in the AWS_ACCESS_KEY and AWS_SECRET_KEY
+# environment variables.
+
+- name: Upload classifcation data to S3 Bucket
+  hosts: localhost
+  gather_facts: False
+  vars_files:
+    - settings.yml
+  tasks:
+  - name: Upload state and county boundaries
+    s3_sync:
+      bucket: "{{ bucket_name }}"
+      file_root: ../data/geo
+      key_prefix: data/geo
+      file_change_strategy: date_size
+      permission: public-read
+      cache_control: "public, max-age=604800"
+      include: "*.json"
+      region: "{{ aws_region }}"
+  - name: Upload county classification data
+    s3_sync:
+      bucket: "{{ bucket_name }}"
+      file_root: ../output/classification
+      key_prefix: output/classification
+      file_change_strategy: date_size
+      permission: public-read
+      cache_control: "public, max-age=3600"
+      include: "*.json"
+      region: "{{ aws_region }}"
+  - debug:
+      msg: "Data uploaded to S3 bucket {{ bucket_name }} in region {{ aws_region }}"


### PR DESCRIPTION
We want to move the approx 3200 JSON files out of the github repository, see https://github.com/obuchel/classification/issues/4. The simplest solution is to serve them from an S3 bucket.

With the changes in this PR we can

- setup an S3 bucket `ecv-county-maps` to store classification data and county + state boundaries
- upload generated data to S3
- change maps to use S3 by default, instead of GitHub
- keep using locally generated files during development

See the [README.md](https://github.com/obuchel/classification/pull/13/files?short_path=04c6e90#diff-04c6e90faac2675aa89e2176d2eec7d8) for more details.

## Notes

I have already uploaded the JSON files to the S3 bucket, containing the data upto 6/4/20.

## Deployment

- Merge this pull request
- The maps at https://www.endcoronavirus.org/us-counties should still take their JSON data from GitHub at this point. Check that they still work.

The S3 bucket should be owned by NECSI, as they will have to pay for the traffic. See https://github.com/obuchel/classification/issues/4 for a cost estimate. 

Create the S3 bucket and upload data to it as described in README.md. That will need the AWS credentials of someone at NECSI.

Switch to serving by S3:

- in SquareSpace, edit the page for https://www.endcoronavirus.org/us-counties
- find the IFrame and change `https://obuchel.github.io/classification/classification_map.html` to
   `https://obuchel.github.io/classification/classification_map.html?s3bucket=ecv-county-maps`
- use the browser console to check that JSON files are now retrieved from S3
- make a similar change to the other map. Check again that S3 is used.


## Steps for future Pull Requests

- remove a few thousand JSON files from the repository 
- automate the daily update of the maps with GitHub actions
- make serving from S3 the default (remove the parameter `useS3=true`)